### PR TITLE
delete unnecessary judgment of parseState

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -85,9 +85,6 @@ export const recoilPersist = (
   }
 
   const parseState = (state: string) => {
-    if (state === undefined) {
-      return {}
-    }
     try {
       return JSON.parse(state)
     } catch (e) {


### PR DESCRIPTION
String type and undefined won't be equal